### PR TITLE
Adding constructor to ManagedPooledDataSource without MetricRegistry,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Status
 ![Build Status](https://codeship.com/projects/37601470-cb27-0133-b906-266ee181f653/status?branch=master)
 [![Coverage Status](https://coveralls.io/repos/github/mtakaki/dropwizard-hikaricp/badge.svg?branch=master)](https://coveralls.io/github/mtakaki/dropwizard-hikaricp?branch=master)
+[![Codacy Badge](https://api.codacy.com/project/badge/grade/b6b6a9a48d334299ab49f012643bc046)](https://www.codacy.com/app/mitsuotakaki/dropwizard-hikaricp)
 [![Download](https://maven-badges.herokuapp.com/maven-central/com.github.mtakaki/dropwizard-hikaricp/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.mtakaki/dropwizard-hikaricp)
 [![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.github.mtakaki/dropwizard-hikaricp/badge.svg)](http://www.javadoc.io/doc/com.github.mtakaki/dropwizard-hikaricp)
 

--- a/src/main/java/io/dropwizard/db/ManagedPooledDataSource.java
+++ b/src/main/java/io/dropwizard/db/ManagedPooledDataSource.java
@@ -18,8 +18,12 @@ public class ManagedPooledDataSource extends HikariDataSource implements Managed
      *            metrics.
      */
     public ManagedPooledDataSource(final HikariConfig config, final MetricRegistry metricRegistry) {
-        super(config);
+        this(config);
         this.setMetricRegistry(metricRegistry);
+    }
+
+    public ManagedPooledDataSource(final HikariConfig config) {
+        super(config);
     }
 
     // JDK6 has JDBC 4.0 which doesn't have this -- don't add @Override


### PR DESCRIPTION
… so we can suppress adding the metrics in case it's not needed. Also adding Codacy code quality score.
