### PR TITLE
Upgrading to dropwizard-db 2.0.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>2.0.20</dropwizard.version>
+        <dropwizard.version>2.0.21</dropwizard.version>
         <hikaricp.version>4.0.3</hikaricp.version>
         <!-- Flaky test setting, re-run more 2 times in case of a failure -->
         <surefire.rerunFailingTestsCount>2</surefire.rerunFailingTestsCount>


### PR DESCRIPTION
Latest release of dropwizard-db is 2.0.21. Please let me know if I need to take additional steps to upgrade.